### PR TITLE
bump xcode to 12.2.0 for prebuilds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ test-prebuild-linux-base: &test-prebuild-linux-base
 
 prebuild-darwin-base: &prebuild-darwin-base
   macos:
-    xcode: "10.2.0"
+    xcode: "12.2.0"
   working_directory: ~/dd-native-metrics-js
   steps:
     - checkout-and-yarn-install


### PR DESCRIPTION
This PR bumps XCode to 12.2.0 for prebuilds. CircleCI no longer supports 10.2.0 so the nightly build started failing. Updating means losing support for Mojave, but it will allow us to eventually support ARM macs.