### PR TITLE
add prebuilds for apple silicon macs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ test-prebuild-linux-base: &test-prebuild-linux-base
 
 prebuild-darwin-base: &prebuild-darwin-base
   macos:
-    xcode: "12.2.0"
+    xcode: "12.5.1"
   working_directory: ~/dd-native-metrics-js
   steps:
     - checkout-and-yarn-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,14 +68,6 @@ test-prebuild-linux-base: &test-prebuild-linux-base
         name: Unit tests
         command: yarn test
 
-prebuild-darwin-base: &prebuild-darwin-base
-  working_directory: ~/dd-native-metrics-js
-  steps:
-    - checkout-and-yarn-install
-    - *yarn-prebuild
-    - *yarn-test
-    - *persist-prebuilds
-
 prebuild-win32-base: &prebuild-win32-base
   executor:
     name: win/default
@@ -210,7 +202,12 @@ jobs:
   # Prebuilds (darwin)
 
   macos-intel:
-    <<: *prebuild-darwin-base
+    working_directory: ~/dd-native-metrics-js
+    steps:
+      - checkout-and-yarn-install
+      - *yarn-prebuild
+      - *yarn-test
+      - *persist-prebuilds
     macos:
       xcode: "12.2.0"
     environment:
@@ -218,7 +215,12 @@ jobs:
       - NODE_VERSIONS=12 - 17
 
   macos-apple:
-    <<: *prebuild-darwin-base
+    working_directory: ~/dd-native-metrics-js
+    steps:
+      - checkout-and-yarn-install
+      - *yarn-prebuild
+      # TODO: run tests when CircleCI adds Apple silicon executors
+      - *persist-prebuilds
     macos:
       xcode: "12.5.1"
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
   macos:
     <<: *prebuild-darwin-base
     environment:
-      - ARCH=ia32,x64
+      - ARCH=ia32,x64,arm64
       - NODE_VERSIONS=12 - 17
 
   # Prebuilds (win32)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,6 @@ test-prebuild-linux-base: &test-prebuild-linux-base
         command: yarn test
 
 prebuild-darwin-base: &prebuild-darwin-base
-  macos:
-    xcode: "12.5.1"
   working_directory: ~/dd-native-metrics-js
   steps:
     - checkout-and-yarn-install
@@ -211,10 +209,20 @@ jobs:
 
   # Prebuilds (darwin)
 
-  macos:
+  macos-intel:
     <<: *prebuild-darwin-base
+    macos:
+      xcode: "12.2.0"
     environment:
-      - ARCH=ia32,x64,arm64
+      - ARCH=ia32,x64
+      - NODE_VERSIONS=12 - 17
+
+  macos-apple:
+    <<: *prebuild-darwin-base
+    macos:
+      xcode: "12.5.1"
+    environment:
+      - ARCH=arm64
       - NODE_VERSIONS=12 - 17
 
   # Prebuilds (win32)
@@ -285,7 +293,8 @@ workflows:
             - linux-ia32-12
       - alpine-x64
       - alpine-ia32
-      - macos
+      - macos-intel
+      - macos-apple
       - windows
       - prebuilds:
           requires:
@@ -299,7 +308,8 @@ workflows:
             - alpine-x64-16-test
             - alpine-x64-14-test
             - alpine-x64-12-test
-            - macos
+            - macos-intel
+            - macos-apple
             - windows
   nightly:
     triggers:

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,7 +9,7 @@
       "<!(node -e \"require('nan')\")"
     ],
     "xcode_settings": {
-      "MACOSX_DEPLOYMENT_TARGET": "10.10",
+      "MACOSX_DEPLOYMENT_TARGET": "11.0",
       "OTHER_CFLAGS": [
         "-std=c++14",
         "-stdlib=libc++",

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,7 +9,7 @@
       "<!(node -e \"require('nan')\")"
     ],
     "xcode_settings": {
-      "MACOSX_DEPLOYMENT_TARGET": "11.0",
+      "MACOSX_DEPLOYMENT_TARGET": "10.10",
       "OTHER_CFLAGS": [
         "-std=c++14",
         "-stdlib=libc++",

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -40,6 +40,7 @@ function prebuildify () {
         'node-gyp rebuild',
       `--target=${target.version}`,
       `--target_arch=${arch}`,
+      `--arch=${arch}`,
       `--devdir=${cache}`,
       '--release',
       '--jobs=max',


### PR DESCRIPTION
This PR adds prebuilds for Apple silicon Macs so that Xcode doesn't need to be installed to use the addon.