### PR TITLE
remove binding.gyp from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,6 @@
 !LICENSE
 !LICENSE-3rdparty.csv
 !README.md
-!binding.gyp
 !index.d.ts
 !index.js
 !package.json

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/dd-native-metrics-js#readme",
   "scripts": {
-    "install": "(node scripts/should_rebuild && node-gyp-build) || exit 0",
     "rebuild": "node-gyp rebuild",
     "lint": "node scripts/check_licenses.js && eslint .",
     "test": "mocha 'test/**/*.spec.js'"

--- a/scripts/should_rebuild.js
+++ b/scripts/should_rebuild.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const { CI, INIT_CWD, PWD } = process.env
-
-// skip for local development, CI, or very old package managers without INIT_CWD
-if (CI === 'true' || !INIT_CWD || INIT_CWD.includes(PWD)) {
-  process.exit(1)
-}


### PR DESCRIPTION
This file is no longer needed now that prebuilds exist for all supported platforms and architectures. It also has the benefit of removing the need for an `install` script which was triggering security tools.