### PR TITLE
increase timeout for worker thread test

### DIFF
--- a/test/metrics.spec.js
+++ b/test/metrics.spec.js
@@ -106,7 +106,9 @@ describe('metrics', () => {
     })
   })
 
-  it('should support worker threads', done => {
+  it('should support worker threads', function (done) {
+    this.timeout(10000)
+
     const worker = new Worker(path.join(__dirname, 'worker.js'))
 
     worker.once('exit', code => {


### PR DESCRIPTION
Because Windows is slow.