### PR TITLE
move nan to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "node": ">=12"
   },
   "dependencies": {
-    "nan": "^2.15.0",
     "node-gyp-build": "^3.9.0"
   },
   "devDependencies": {
@@ -33,6 +32,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0",
-    "mocha": "^9.0.3"
+    "mocha": "^9.0.3",
+    "nan": "^2.15.0"
   }
 }


### PR DESCRIPTION
Nan is only needed to build, and the native add-on is now always prebuilt.