### PR TITLE
remove unused folders from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,5 @@
 *
-!src/**/*
 !prebuilds/**/*
-!scripts/**/*
 !CONTRIBUTING.md
 !LICENSE
 !LICENSE-3rdparty.csv


### PR DESCRIPTION
The `src` folder is not longer used since the native add-on is always prebuilt, and the `scripts` folder only has development scripts.