### PR TITLE
fix worker test timeout being imprecise on windows

### DIFF
--- a/test/worker.js
+++ b/test/worker.js
@@ -16,7 +16,7 @@ setImmediate(() => {
   expect(stats.eventLoop.count).to.equal(1)
 
   // Check for 50ms instead of 100ms because it's not precise.
-  expect(stats.eventLoop.min).to.be.gte(50 * 1e6).and.lte(100 * 1e7)
-  expect(stats.eventLoop.max).to.be.gte(50 * 1e6).and.lte(100 * 1e7)
-  expect(stats.eventLoop.sum).to.be.gte(50 * 1e6).and.lte(100 * 1e7)
+  expect(stats.eventLoop.min).to.be.gte(50 * 1e6).and.lte(500 * 1e7)
+  expect(stats.eventLoop.max).to.be.gte(50 * 1e6).and.lte(500 * 1e7)
+  expect(stats.eventLoop.sum).to.be.gte(50 * 1e6).and.lte(500 * 1e7)
 })

--- a/test/worker.js
+++ b/test/worker.js
@@ -15,8 +15,8 @@ setImmediate(() => {
 
   expect(stats.eventLoop.count).to.equal(1)
 
-  // Check for 90ms instead of 100ms because it's not precise.
-  expect(stats.eventLoop.min).to.be.gte(90 * 1e6).and.lte(100 * 1e7)
-  expect(stats.eventLoop.max).to.be.gte(90 * 1e6).and.lte(100 * 1e7)
-  expect(stats.eventLoop.sum).to.be.gte(90 * 1e6).and.lte(100 * 1e7)
+  // Check for 50ms instead of 100ms because it's not precise.
+  expect(stats.eventLoop.min).to.be.gte(50 * 1e6).and.lte(100 * 1e7)
+  expect(stats.eventLoop.max).to.be.gte(50 * 1e6).and.lte(100 * 1e7)
+  expect(stats.eventLoop.sum).to.be.gte(50 * 1e6).and.lte(100 * 1e7)
 })


### PR DESCRIPTION
Windows will sometimes have timing values smaller than the value provided to timers, and the error margin is greater than just 10%, but 50% should be safe.