### PR TITLE
Improve first cpu metrics value and add test

### DIFF
--- a/src/metrics/Process.hpp
+++ b/src/metrics/Process.hpp
@@ -18,7 +18,7 @@ namespace datadog {
   };
 
   Process::Process() {
-    uv_getrusage(&usage_);
+    memset(&usage_, 0, sizeof(usage_));
   }
 
   void Process::inject(Object carrier) {

--- a/test/metrics.spec.js
+++ b/test/metrics.spec.js
@@ -14,6 +14,18 @@ describe('metrics', () => {
     nativeMetrics.stop()
   })
 
+  // NOTE: This test needs to be first!
+  it('should have realistic cpu stats on first stats call', () => {
+    const { cpu } = nativeMetrics.stats()
+    const { user, system } = process.cpuUsage()
+
+    expect(cpu.user).to.be.greaterThan(user * 0.9)
+    expect(cpu.user).to.be.lessThanOrEqual(user)
+
+    expect(cpu.system).to.be.greaterThan(system * 0.9)
+    expect(cpu.system).to.be.lessThanOrEqual(system)
+  })
+
   it('should collect stats', () => {
     const stats = nativeMetrics.stats()
 


### PR DESCRIPTION
I've added a test to prove the data from the first call to `metrics.stats()` does not produce garbage cpu data. I've also changed from calling `uv_getrusage`, which will fill the `usage_` struct with the _current_ cpu time with a `memset` to zero. This means the first call will get the cpu time from the start of the process rather than from when this native module was loaded.