### PR TITLE
Make CI require semver labels

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,17 @@
+name: Pull Request Labels
+
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+    branches:
+      - main
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 1
+          labels: "semver-patch, semver-minor, semver-major"


### PR DESCRIPTION
Just copy/pasting the semver labels GHA job from dd-trace-js.