### PR TITLE
Revert "Fix garbage collection metrics (#50)"

### DIFF
--- a/src/metrics/main.cpp
+++ b/src/metrics/main.cpp
@@ -44,7 +44,7 @@ namespace datadog {
 
     public:
       NativeMetrics(Env env, Object exports)
-        : gcInfo(env), loopInfo(new EventLoop(env)) {
+        : loopInfo(new EventLoop(env)) {
         DefineAddon(exports, {
           InstanceMethod("start", &NativeMetrics::Start),
           InstanceMethod("stop", &NativeMetrics::Stop),


### PR DESCRIPTION
This reverts commit 50a18ca889fecc0bfe89baba20fbb87b014887e2.

It looks like this fails in some versions in CI for some reason which I can't reproduce locally where `unknown` end up as the only GC type available.

@ikonst It looks like CI was not running for #50 so this was missed.

Interestingly, it looks like after reverting, all tests are passing on all platforms and all versions of Node.