### PR TITLE
fix segfault from worker threads when terminated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,5 +15,5 @@ jobs:
       target-name: 'metrics'
       package-manager: 'yarn'
       cache: true
-      min-node-version: 14
+      min-node-version: 16
       napi: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       target-name: 'metrics'
       package-manager: 'yarn'
       cache: true
-      min-node-version: 14
+      min-node-version: 16
       napi: true
 
   publish:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "compile_commands": "node-gyp configure --release -- -f gyp.generator.compile_commands_json.py && mv Release/compile_commands.json ./",
     "rebuild": "node-gyp rebuild -j max",
     "lint": "node scripts/check_licenses.js && eslint .",
-    "test": "mocha 'test/**/*.spec.js'"
+    "test": "mocha 'test/**/*.spec.js' && node test/main"
   },
   "keywords": [
     "datadog",

--- a/test/main.js
+++ b/test/main.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const path = require('path')
+const { Worker } = require('worker_threads')
+
+const worker = new Worker(path.join(__dirname, 'worker.js'))
+
+setTimeout(() => {
+  worker.terminate()
+}, 1000)


### PR DESCRIPTION
Fixes DataDog/dd-trace-js/issues/2627

I used a separate file for testing because for some reason I can't seem to get the segmentation fault when doing the exact same thing as part of the Mocha test suite.

Fixing the issue requires either a different code path for Node 14 and >=16 because the API needed to make this work didn't exist before, or dropping Node 14 entirely. Since we no longer support Node 14, I went with the latter.