### PR TITLE
fix: reset timestamps on enable

### DIFF
--- a/src/metrics/EventLoop.hpp
+++ b/src/metrics/EventLoop.hpp
@@ -109,6 +109,9 @@ namespace datadog {
   void EventLoop::Enable() {
     if (enabled_) return;
     enabled_ = true;
+    check_time_ = uv_hrtime();
+    prepare_time_ = check_time_;
+
     uv_check_start(&check_handle_, &EventLoop::check_cb);
     uv_prepare_start(&prepare_handle_, &EventLoop::prepare_cb);
   }


### PR DESCRIPTION
This resets the `check_time_` and `prepare_time_` properties when calling `EventLoop::Enable`. Without this, those properties would hold the values from the previous callback before `Disable` was called (or from when the `EventLoop` was instantiated), causing a huge spike in the reported latency metrics right after re-enabling. Basically it would count the time it was disabled as latency, which is incorrect.