### PR TITLE
Use "swallow unthrowable exceptions" 

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,7 +9,8 @@
       "<!@(node -p \"require('node-addon-api').include\")"
     ],
     "defines": [
-      "NAPI_DISABLE_CPP_EXCEPTIONS"
+      "NAPI_DISABLE_CPP_EXCEPTIONS",
+      "NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS"
     ],
     "xcode_settings": {
       "MACOSX_DEPLOYMENT_TARGET": "10.10",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "compile_commands": "node-gyp configure --release -- -f gyp.generator.compile_commands_json.py && mv Release/compile_commands.json ./",
     "rebuild": "node-gyp rebuild -j max",
     "lint": "node scripts/check_licenses.js && eslint .",
-    "test": "mocha -n expose-gc 'test/**/*.spec.js' && node test/main"
+    "test": "mocha -n expose-gc 'test/**/*.spec.js' && node test/main && node test/crash-repro"
   },
   "keywords": [
     "datadog",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "compile_commands": "node-gyp configure --release -- -f gyp.generator.compile_commands_json.py && mv Release/compile_commands.json ./",
     "rebuild": "node-gyp rebuild -j max",
     "lint": "node scripts/check_licenses.js && eslint .",
-    "test": "mocha -n expose-gc 'test/**/*.spec.js' && node test/main && node test/crash-repro"
+    "test": "mocha -n expose-gc 'test/**/*.spec.js' && node test/main"
   },
   "keywords": [
     "datadog",

--- a/test/crash-repro-worker.js
+++ b/test/crash-repro-worker.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const metrics = require('..')
+
+metrics.start()
+
+function spin () {
+  for (let i = 0; i < 50; i++) {
+    metrics.stats()
+  }
+  setImmediate(spin)
+}
+
+spin()

--- a/test/crash-repro.js
+++ b/test/crash-repro.js
@@ -3,10 +3,6 @@
 const path = require('path')
 const { Worker } = require('worker_threads')
 
-// Preload the native module in the main thread so worker threads don't
-// race on first dlopen/NAPI registration when spawned concurrently.
-require('..')
-
 const WORKER_PATH = path.join(__dirname, 'crash-repro-worker.js')
 const CONCURRENCY = Number(process.env.REPRO_CONCURRENCY) || 16
 const DURATION_MS = Number(process.env.REPRO_DURATION_MS) || 5000

--- a/test/crash-repro.js
+++ b/test/crash-repro.js
@@ -9,37 +9,55 @@ const DURATION_MS = Number(process.env.REPRO_DURATION_MS) || 5000
 const MIN_LIFETIME_MS = 5
 const MAX_LIFETIME_MS = 50
 
-const deadline = Date.now() + DURATION_MS
-let spawned = 0
-let terminated = 0
-let inflight = 0
+function run () {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + DURATION_MS
+    let spawned = 0
+    let terminated = 0
+    let inflight = 0
+    let settled = false
 
-function churn () {
-  if (Date.now() >= deadline) {
-    if (inflight === 0) {
-      console.log(`no crash after ${DURATION_MS}ms: spawned=${spawned} terminated=${terminated}`)
-      process.exit(0)
+    function churn () {
+      if (settled) return
+
+      if (Date.now() >= deadline) {
+        if (inflight === 0) {
+          settled = true
+          console.log(`no crash after ${DURATION_MS}ms: spawned=${spawned} terminated=${terminated}`)
+          resolve()
+        }
+        return
+      }
+
+      const worker = new Worker(WORKER_PATH)
+      spawned++
+      inflight++
+
+      worker.on('error', (err) => {
+        if (settled) return
+        settled = true
+        reject(err)
+      })
+
+      worker.on('exit', () => {
+        inflight--
+        terminated++
+        churn()
+      })
+
+      const lifetime = MIN_LIFETIME_MS + Math.random() * (MAX_LIFETIME_MS - MIN_LIFETIME_MS)
+      setTimeout(() => worker.terminate(), lifetime)
     }
-    return
-  }
 
-  const worker = new Worker(WORKER_PATH)
-  spawned++
-  inflight++
-
-  worker.on('error', (err) => {
-    console.error('worker error:', err)
-    process.exit(2)
+    for (let i = 0; i < CONCURRENCY; i++) churn()
   })
-
-  worker.on('exit', () => {
-    inflight--
-    terminated++
-    churn()
-  })
-
-  const lifetime = MIN_LIFETIME_MS + Math.random() * (MAX_LIFETIME_MS - MIN_LIFETIME_MS)
-  setTimeout(() => worker.terminate(), lifetime)
 }
 
-for (let i = 0; i < CONCURRENCY; i++) churn()
+module.exports = { run }
+
+if (require.main === module) {
+  run().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/test/crash-repro.js
+++ b/test/crash-repro.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const path = require('path')
+const { Worker } = require('worker_threads')
+
+const WORKER_PATH = path.join(__dirname, 'crash-repro-worker.js')
+const CONCURRENCY = Number(process.env.REPRO_CONCURRENCY) || 16
+const DURATION_MS = Number(process.env.REPRO_DURATION_MS) || 5000
+const MIN_LIFETIME_MS = 5
+const MAX_LIFETIME_MS = 50
+
+const deadline = Date.now() + DURATION_MS
+let spawned = 0
+let terminated = 0
+let inflight = 0
+
+function churn () {
+  if (Date.now() >= deadline) {
+    if (inflight === 0) {
+      console.log(`no crash after ${DURATION_MS}ms: spawned=${spawned} terminated=${terminated}`)
+      process.exit(0)
+    }
+    return
+  }
+
+  const worker = new Worker(WORKER_PATH)
+  spawned++
+  inflight++
+
+  worker.on('error', (err) => {
+    console.error('worker error:', err)
+    process.exit(2)
+  })
+
+  worker.on('exit', () => {
+    inflight--
+    terminated++
+    churn()
+  })
+
+  const lifetime = MIN_LIFETIME_MS + Math.random() * (MAX_LIFETIME_MS - MIN_LIFETIME_MS)
+  setTimeout(() => worker.terminate(), lifetime)
+}
+
+for (let i = 0; i < CONCURRENCY; i++) churn()

--- a/test/crash-repro.js
+++ b/test/crash-repro.js
@@ -9,55 +9,31 @@ const DURATION_MS = Number(process.env.REPRO_DURATION_MS) || 5000
 const MIN_LIFETIME_MS = 5
 const MAX_LIFETIME_MS = 50
 
-function run () {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + DURATION_MS
-    let spawned = 0
-    let terminated = 0
-    let inflight = 0
-    let settled = false
+const deadline = Date.now() + DURATION_MS
+let spawned = 0
+let terminated = 0
+let inflight = 0
 
-    function churn () {
-      if (settled) return
-
-      if (Date.now() >= deadline) {
-        if (inflight === 0) {
-          settled = true
-          console.log(`no crash after ${DURATION_MS}ms: spawned=${spawned} terminated=${terminated}`)
-          resolve()
-        }
-        return
-      }
-
-      const worker = new Worker(WORKER_PATH)
-      spawned++
-      inflight++
-
-      worker.on('error', (err) => {
-        if (settled) return
-        settled = true
-        reject(err)
-      })
-
-      worker.on('exit', () => {
-        inflight--
-        terminated++
-        churn()
-      })
-
-      const lifetime = MIN_LIFETIME_MS + Math.random() * (MAX_LIFETIME_MS - MIN_LIFETIME_MS)
-      setTimeout(() => worker.terminate(), lifetime)
+function churn () {
+  if (Date.now() >= deadline) {
+    if (inflight === 0) {
+      console.log(`no crash after ${DURATION_MS}ms: spawned=${spawned} terminated=${terminated}`)
     }
+    return
+  }
 
-    for (let i = 0; i < CONCURRENCY; i++) churn()
+  const worker = new Worker(WORKER_PATH)
+  spawned++
+  inflight++
+
+  worker.on('exit', () => {
+    inflight--
+    terminated++
+    churn()
   })
+
+  const lifetime = MIN_LIFETIME_MS + Math.random() * (MAX_LIFETIME_MS - MIN_LIFETIME_MS)
+  setTimeout(() => worker.terminate(), lifetime)
 }
 
-module.exports = { run }
-
-if (require.main === module) {
-  run().catch((err) => {
-    console.error(err)
-    process.exit(1)
-  })
-}
+for (let i = 0; i < CONCURRENCY; i++) churn()

--- a/test/crash-repro.js
+++ b/test/crash-repro.js
@@ -3,6 +3,10 @@
 const path = require('path')
 const { Worker } = require('worker_threads')
 
+// Preload the native module in the main thread so worker threads don't
+// race on first dlopen/NAPI registration when spawned concurrently.
+require('..')
+
 const WORKER_PATH = path.join(__dirname, 'crash-repro-worker.js')
 const CONCURRENCY = Number(process.env.REPRO_CONCURRENCY) || 16
 const DURATION_MS = Number(process.env.REPRO_DURATION_MS) || 5000

--- a/test/main.js
+++ b/test/main.js
@@ -1,12 +1,17 @@
 'use strict'
 
-const path = require('path')
-const { Worker } = require('worker_threads')
+const tests = [
+  require('./worker-termination'),
+  require('./crash-repro')
+]
 
-for (let i = 0; i < 10; i++) {
-  const worker = new Worker(path.join(__dirname, 'worker.js'))
-
-  setTimeout(() => {
-    worker.terminate()
-  }, 1000)
+async function main () {
+  for (const test of tests) {
+    await test.run()
+  }
 }
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/test/main.js
+++ b/test/main.js
@@ -1,17 +1,4 @@
 'use strict'
 
-const tests = [
-  require('./worker-termination'),
-  require('./crash-repro')
-]
-
-async function main () {
-  for (const test of tests) {
-    await test.run()
-  }
-}
-
-main().catch((err) => {
-  console.error(err)
-  process.exit(1)
-})
+require('./worker-termination')
+require('./crash-repro')

--- a/test/main.js
+++ b/test/main.js
@@ -1,4 +1,8 @@
 'use strict'
 
+// Preload the native module in the main thread so worker threads don't
+// race on first dlopen/NAPI registration when spawned concurrently.
+require('..')
+
 require('./worker-termination')
 require('./crash-repro')

--- a/test/worker-termination.js
+++ b/test/worker-termination.js
@@ -7,24 +7,7 @@ const WORKER_PATH = path.join(__dirname, 'worker.js')
 const WORKER_COUNT = 10
 const WORKER_LIFETIME_MS = 1000
 
-function run () {
-  return new Promise((resolve) => {
-    let remaining = WORKER_COUNT
-    for (let i = 0; i < WORKER_COUNT; i++) {
-      const worker = new Worker(WORKER_PATH)
-      worker.on('exit', () => {
-        if (--remaining === 0) resolve()
-      })
-      setTimeout(() => worker.terminate(), WORKER_LIFETIME_MS)
-    }
-  })
-}
-
-module.exports = { run }
-
-if (require.main === module) {
-  run().catch((err) => {
-    console.error(err)
-    process.exit(1)
-  })
+for (let i = 0; i < WORKER_COUNT; i++) {
+  const worker = new Worker(WORKER_PATH)
+  setTimeout(() => worker.terminate(), WORKER_LIFETIME_MS)
 }

--- a/test/worker-termination.js
+++ b/test/worker-termination.js
@@ -3,10 +3,6 @@
 const path = require('path')
 const { Worker } = require('worker_threads')
 
-// Preload the native module in the main thread so worker threads don't
-// race on first dlopen/NAPI registration when spawned concurrently.
-require('..')
-
 const WORKER_PATH = path.join(__dirname, 'worker.js')
 const WORKER_COUNT = 10
 const WORKER_LIFETIME_MS = 1000

--- a/test/worker-termination.js
+++ b/test/worker-termination.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const path = require('path')
+const { Worker } = require('worker_threads')
+
+const WORKER_PATH = path.join(__dirname, 'worker.js')
+const WORKER_COUNT = 10
+const WORKER_LIFETIME_MS = 1000
+
+function run () {
+  return new Promise((resolve) => {
+    let remaining = WORKER_COUNT
+    for (let i = 0; i < WORKER_COUNT; i++) {
+      const worker = new Worker(WORKER_PATH)
+      worker.on('exit', () => {
+        if (--remaining === 0) resolve()
+      })
+      setTimeout(() => worker.terminate(), WORKER_LIFETIME_MS)
+    }
+  })
+}
+
+module.exports = { run }
+
+if (require.main === module) {
+  run().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/test/worker-termination.js
+++ b/test/worker-termination.js
@@ -3,6 +3,10 @@
 const path = require('path')
 const { Worker } = require('worker_threads')
 
+// Preload the native module in the main thread so worker threads don't
+// race on first dlopen/NAPI registration when spawned concurrently.
+require('..')
+
 const WORKER_PATH = path.join(__dirname, 'worker.js')
 const WORKER_COUNT = 10
 const WORKER_LIFETIME_MS = 1000


### PR DESCRIPTION
We're still getting some native-metrics induced crashes, e.g.:
```
Error UnixSignal: Process terminated with SI_TKILL (SIGABRT)
0x7d0f3530fb2c pthread_kill
0x7d0f352b627e gsignal
0x7d0f352998ff abort
0x735dbd node::SPrintFImpl<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>
0x856005 napi_module_register_by_symbol
0x7d0f34059c5a Napi::Error::Fatal
0x7d0f34056171 datadog::Heap::ToJSON
0x7d0f34060f1b datadog::NativeMetrics::Stats
0x7d0f3405a56d Napi::InstanceWrap<datadog::NativeMetrics>::InstanceMethodCallbackWrapper
0x824271 node::HistogramBase::RegisterExternalReferences
0x7d08a7dcf08d
0x7d0aac000090
0x7d088838a223
0x7d08a7dcd654
0x7d0888163cc5
0x7d088816ad08
0x7d08a7dcb21c
0x7d08a7dcaf67
0xd58621 v8::internal::HeapObject::HeapObjectPrint
0xd594cf v8::internal::HeapObject::HeapObjectPrint
0xbc56d7 v8::Object::GetPropertyNames
0x80da36 node::Environment::Environment
0x1933a34 _tr_flush_block
0x193785a uv_timer_start
0x78a155 node::AsyncResource::AsyncResource
0xa28f61 node::worker::Worker::New
0xa290d6 node::worker::Worker::New
0x7d0f3530daa4
```

 `Error::Fatal` comes exclusively from `NAPI_FATAL_IF_FAILED`/`NAPI_CHECK` macros. In `Heap::ToJSON` the only reachable path to it is inside `Error::ThrowAsJavaScriptException` at `napi-inl.h:3080`:

  ```cpp
  napi_status status = napi_throw(_env, Value());
  #ifdef NAPI_CPP_EXCEPTIONS
    if (status != napi_ok) throw Error::New(_env);
  #else
    NAPI_FATAL_IF_FAILED(status, "Error::ThrowAsJavaScriptException", "napi_throw");
  #endif
```

So the sequence inside Heap::ToJSON is:

1. One of the N-API calls in the loop (Array::New, Object::New, etc.) returns non-napi_ok.
2. NAPI_THROW_IF_FAILED tries to surface it via Error::New(env).ThrowAsJavaScriptException().
3. napi_throw itself fails too.
4. With NAPI_DISABLE_CPP_EXCEPTIONS set (binding.gyp:12) and NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS not set, that failure becomes an unconditional napi_fatal_error → abort.

The bottom of the stack is a worker-thread entry (node::worker::Worker::New + pthread frames). This is a worker isolate that entered a terminating state — almost certainly worker.terminate() fired from another thread while JS inside the worker was mid-call to nativeMetrics.stats().

Once V8 flips the isolate to "terminating", further N-API calls return napi_pending_exception / napi_generic_failure, and napi_throw also can't succeed — so the library falls through to Fatal.

`NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS`is the supported node-addon-api escape hatch for exactly this race: when napi_throw reports napi_pending_exception because the env is terminating, the exception is swallowed instead of aborting. 

Claude tells me that it "is what the node-addon-api maintainers recommend for this scenario and what most addons (incl. Node core's own) use" but I have no way to verify that.

Jira: [APMLP-1310]

[APMLP-1310]: https://datadoghq.atlassian.net/browse/APMLP-1310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ