### PR TITLE
OIDC and dd-oco-sts updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write # Required for OIDC
       contents: write
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/dd-native-metrics-js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
       id-token: write # Required for OIDC
       contents: write
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/dd-native-metrics-js
+          policy: self.github.release.push-tags
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
       - uses: actions/setup-node@v4
@@ -36,4 +41,4 @@ jobs:
           echo "json=$content" >> "$GITHUB_OUTPUT"
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
-          git push origin v${{ fromJson(steps.pkg.outputs.json).version }}
+          git push https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/${{ github.repository }}.git v${{ fromJson(steps.pkg.outputs.json).version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     permissions:
+      id-token: write # Required for OIDC
       contents: write
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
       - uses: actions/setup-node@v4
         with:
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish
       - id: pkg

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "2.0.0-pre",
   "description": "Native metrics collector for libuv and v8",
   "main": "index.js",
-  "repository": "git@github.com:DataDog/dd-native-metrics-js.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataDog/dd-native-metrics-js.git"
+  },
   "author": "Datadog Inc. <info@datadoghq.com>",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/dd-native-metrics-js#readme",


### PR DESCRIPTION
This repo has fallen behind on several release-specific changes already present in other repos, I'm updating it in a single PR:
* using OIDC to publish packages
* using dd-octo-sts for tag creation

Without these, an attempt to publish a new version of this package will fail.

Jira: [APMLP-1328]

[APMLP-1328]: https://datadoghq.atlassian.net/browse/APMLP-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ