### PR TITLE
ci: add Chainguard STS policy for release tag push

### DIFF
--- a/.github/chainguard/self.github.release.push-tags.sts.yaml
+++ b/.github/chainguard/self.github.release.push-tags.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-native-metrics-js:environment:npm
+
+claim_pattern:
+  event_name: push
+  job_workflow_ref: DataDog/dd-native-metrics-js/\.github/workflows/release\.yml@refs/heads/v[0-9]+\.x
+  ref: refs/heads/v[0-9]+\.x
+  repository: DataDog/dd-native-metrics-js
+
+permissions:
+  contents: write


### PR DESCRIPTION
## Summary

- Adds the missing Chainguard STS policy file required by the `dd-octo-sts-action` in the release workflow
- The policy grants `contents: write` permission scoped to the `npm` environment, allowing the workflow to push the git tag after publishing
- Modeled after the equivalent policy in [DataDog/pprof-nodejs](https://github.com/DataDog/pprof-nodejs)

## Test plan

- [ ] Verify the release workflow succeeds on a `v*.x` branch push

> Generated by [Claude Code](https://claude.ai/claude-code)