### PR TITLE
PROF-15218: Update CI actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,13 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v7
+        with:
+          name: prebuilds
+          path: prebuilds
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
       - run: yarn
       - name: Compute module size tree and report
         uses: qard/heaviest-objects-in-the-universe@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,12 @@ jobs:
         with:
           scope: DataDog/dd-native-metrics-js
           policy: self.github.release.push-tags
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v7
+        with:
+          name: prebuilds
+          path: prebuilds
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
GitHub deprecated the Node.js 20 runtime used by older versions of the `actions/*` actions. Bump them to versions that run on Node.js 24, matching DataDog/action-prebuildify:

- `actions/checkout` -> v7
- `actions/setup-node` -> v6
- `actions/download-artifact` -> v7

The `download-artifact` bump also requires a fix: v5+ no longer nests a single nameless artifact under a directory named after it; it extracts directly into the target path. These jobs `needs: build` (the reusable action-prebuildify build, which produces a single merged artifact named `prebuilds`) and then run `npm publish` / a package-size report that expect the native binaries under `./prebuilds/`. Adding a `with: { name: prebuilds, path: prebuilds }` block downloads the artifact by name into `./prebuilds`, restoring the old layout.