### PR TITLE
PROF-15218: Support Node.js 26: upgrade mocha to v11, drop Node 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       target-name: 'metrics'
       package-manager: 'yarn'
       cache: true
-      min-node-version: 16
+      min-node-version: 18
       napi: true
 
   package-size:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       target-name: 'metrics'
       package-manager: 'yarn'
       cache: true
-      min-node-version: 16
+      min-node-version: 18
       napi: true
 
   publish:

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "node-option": ["expose-gc"],
+  "spec": "test/**/*.spec.js"
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "compile_commands": "node-gyp configure --release -- -f gyp.generator.compile_commands_json.py && mv Release/compile_commands.json ./",
     "rebuild": "node-gyp rebuild -j max",
     "lint": "node scripts/check_licenses.js && eslint .",
-    "test": "mocha -n expose-gc 'test/**/*.spec.js' && node test/main"
+    "test": "mocha && node test/main"
   },
   "keywords": [
     "datadog",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "apm"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "node-addon-api": "^6.1.0",
@@ -37,6 +37,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0",
-    "mocha": "^9.0.3"
+    "mocha": "^11.7.6"
   }
 }


### PR DESCRIPTION
## What

Make the test suite pass on **Node.js 26** and drop end-of-life Node 16.

- `devDependencies.mocha` `^9.0.3` → `^11.7.6`
- `engines.node` `>=16` → `>=18`
- `build.yml` / `release.yml` `min-node-version` `16` → `18`

## Why

CI fails on the `*-test-26` jobs (every platform) with:

```
$ mocha -n expose-gc 'test/**/*.spec.js' && node test/main
node_modules/yargs/yargs:3
ReferenceError: require is not defined in ES module scope, you can use import instead
Node.js v26.3.1
```

mocha 9 bundles **yargs 16.2.0**, whose extensionless `yargs/yargs` entry is mis-resolved as ESM by Node 26's module loader. mocha 11 ships **yargs 17** (proper `exports` map), which resolves correctly — fixing the failure. This has been red on `main` independently of any action-version change.

mocha 11's engines require **Node ≥18**, so Node 16 is dropped from the matrix. This is consistent anyway: action-prebuildify no longer builds prebuilds for Node <18, so `min-node-version: 16` was already requesting an unsupported version.

## Note on the lockfile

`yarn.lock` is in Yarn Berry (v4) format, but CI installs with **classic yarn 1.22** (via action-prebuildify's test composite) which does not read the Berry lockfile — it resolves dependencies fresh from `package.json` ranges (no `--frozen-lockfile`). So this change takes effect in CI via `package.json` alone, and the committed lockfile does not gate CI. The Berry lockfile should be regenerated with Yarn 4 in a follow-up (I don't have corepack/Yarn 4 available here); it doesn't affect this PR's CI.
