### PR TITLE
fix: drop no-op install script that triggers Yarn build warning

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,5 +1,5 @@
 Component,Origin,License,Copyright
-require,nan,MIT,Copyright 2018 NAN contributors
+require,node-addon-api,MIT,Copyright 2017 Node.js API collaborators
 require,node-gyp-build,MIT,Copyright 2017 Mathias Buus
 dev,chai,MIT,Copyright 2017 Chai.js Assertion Library
 dev,eslint,MIT,Copyright JS Foundation and other contributors https://js.foundation

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-pre",
   "description": "Native metrics collector for libuv and v8",
   "main": "index.js",
+  "gypfile": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/DataDog/dd-native-metrics-js.git"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/dd-native-metrics-js#readme",
   "scripts": {
-    "install": "exit 0",
     "compile_commands": "node-gyp configure --release -- -f gyp.generator.compile_commands_json.py && mv Release/compile_commands.json ./",
     "rebuild": "node-gyp rebuild -j max",
     "lint": "node scripts/check_licenses.js && eslint .",

--- a/test/crash-repro.js
+++ b/test/crash-repro.js
@@ -17,6 +17,7 @@ let inflight = 0
 function churn () {
   if (Date.now() >= deadline) {
     if (inflight === 0) {
+      // eslint-disable-next-line no-console
       console.log(`no crash after ${DURATION_MS}ms: spawned=${spawned} terminated=${terminated}`)
     }
     return

--- a/test/install-scripts.spec.js
+++ b/test/install-scripts.spec.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const assert = require('assert')
+const pkg = require('../package.json')
+
+describe('package manifest', () => {
+  it('declares no npm build lifecycle scripts (Yarn Berry YN0007)', () => {
+    const scripts = pkg.scripts || {}
+    const hooks = ['preinstall', 'install', 'postinstall']
+    const present = hooks.filter((name) => scripts[name] !== undefined)
+    assert.deepStrictEqual(
+      present,
+      [],
+      'package.json must not declare npm build lifecycle scripts (they trigger Yarn Berry YN0007)'
+    )
+  })
+})

--- a/test/install-scripts.spec.js
+++ b/test/install-scripts.spec.js
@@ -14,4 +14,8 @@ describe('package manifest', () => {
       'package.json must not declare npm build lifecycle scripts (they trigger Yarn Berry YN0007)'
     )
   })
+
+  it('opts out of npm implicit node-gyp rebuilds', () => {
+    assert.strictEqual(pkg.gypfile, false)
+  })
 })

--- a/test/metrics.spec.js
+++ b/test/metrics.spec.js
@@ -188,7 +188,7 @@ describe('metrics', () => {
         expect(stats.eventLoop.count).to.be.gte(1)
         expect(stats.eventLoop.max).to.be.lte(50 * 1e6)
         expect(stats.eventLoop.sum).to.be.lte(50 * 1e6)
-        
+
         done()
       })
     })


### PR DESCRIPTION
## Summary

Yarn Berry (Plug'n'Play) prints `YN0007: @datadog/native-metrics must be built` for any dependency that declares an `install`/`preinstall`/`postinstall` script, including the no-op `"install": "exit 0"`. The package ships prebuilt binaries and excludes `binding.gyp` from the published tarball, so a consumer has nothing to build. The script only suppressed npm's implicit `node-gyp rebuild` in the dev tree, which CI does explicitly (`action-prebuildify` installs with `--ignore-scripts`).

Dropping it stops the spurious warning for downstream Yarn Berry users, e.g. dd-trace on Vercel/Next.js.

A regression test asserts the manifest declares no build lifecycle scripts.

## Test plan

- [ ] CI green (build + test via action-prebuildify)
- [ ] `yarn add @datadog/native-metrics` under Yarn Berry (PnP) no longer prints YN0007

Refs: https://github.com/DataDog/dd-trace-js/issues/5432